### PR TITLE
Fix final test result timing

### DIFF
--- a/operatore.html
+++ b/operatore.html
@@ -204,9 +204,6 @@
       cardElem.style.backgroundImage = `url(${immagini[cartaAttuale]})`;
       channel.postMessage({ turno, carta: cartaAttuale });
 
-      if (turno === 50) {
-        setTimeout(mostraRisultatoFinale, 500);
-      }
     }
 
     channel.onmessage = (e) => {
@@ -231,6 +228,8 @@
 
         if (turno < 50) {
           btnNext.disabled = false;
+        } else {
+          mostraRisultatoFinale();
         }
       }
     };


### PR DESCRIPTION
## Summary
- ensure final results are shown only after the 50th response arrives

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68431f522e288330adc093b31376ebb9