### PR TITLE
Display final result on medium page

### DIFF
--- a/medium.html
+++ b/medium.html
@@ -93,6 +93,13 @@
       z-index: 9999;
       pointer-events: none;
     }
+
+    .final-message {
+      margin-top: 1rem;
+      font-size: 1.2rem;
+      font-weight: bold;
+      text-align: center;
+    }
   </style>
 </head>
 <body>
@@ -108,6 +115,7 @@
 
     <div id="carta-coperta"></div>
     <div id="info">In attesa della carta dall'operatore...</div>
+    <div id="final-message" class="final-message"></div>
   </div>
 
   <video id="input_video" playsinline style="display:none;"></video>
@@ -115,6 +123,7 @@
 
   <script>
     const info = document.getElementById("info");
+    const finalMessageElem = document.getElementById("final-message");
     const cards = document.querySelectorAll('.card');
     const canvasElement = document.getElementById('output_canvas');
     const canvasCtx = canvasElement.getContext('2d');
@@ -157,6 +166,12 @@
         selectedCard = null;
         cards.forEach(c => c.classList.remove('selected', 'hovered'));
         info.textContent = "In attesa della carta dall'operatore...";
+        finalMessageElem.textContent = "";
+        return;
+      }
+
+      if (e.data.tipo === "finale") {
+        finalMessageElem.textContent = e.data.messaggio;
         return;
       }
 

--- a/operatore.html
+++ b/operatore.html
@@ -85,6 +85,13 @@
       width: 40px;
       height: auto;
     }
+
+    .final-message {
+      margin-top: 1rem;
+      font-size: 1.2rem;
+      font-weight: bold;
+      text-align: center;
+    }
   </style>
 </head>
 <body>
@@ -115,6 +122,7 @@
       </thead>
       <tbody id="storico"></tbody>
     </table>
+    <div id="final-message" class="final-message"></div>
   </main>
 
   <script>
@@ -133,6 +141,7 @@
     const corretteElem = document.getElementById("corrette");
     const totaliElem = document.getElementById("totali");
     const btnNext = document.getElementById("btn-next");
+    const finalMessageElem = document.getElementById("final-message");
 
     const channel = new BroadcastChannel("zener_test");
 
@@ -169,6 +178,8 @@
         messaggio += "❌ Il test NON è superato secondo il criterio del protocollo.";
       }
 
+      finalMessageElem.textContent = messaggio;
+      channel.postMessage({ tipo: "finale", messaggio });
       alert(messaggio);
       btnNext.disabled = true;
     }
@@ -181,6 +192,7 @@
       corretteElem.textContent = 0;
       totaliElem.textContent = 0;
       storicoElem.innerHTML = '';
+      finalMessageElem.textContent = '';
       btnNext.disabled = false;
       mazzo = creaMazzoZener();
 


### PR DESCRIPTION
## Summary
- add result display elements and styles on both operator and medium pages
- broadcast final result to medium
- show final result when received and reset properly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684327aac308833099149bc6e3119d7e