### PR TITLE
Remove alert dialogs from operatore page

### DIFF
--- a/operatore.html
+++ b/operatore.html
@@ -226,12 +226,12 @@
       // Comunica il reset al medium
       channel.postMessage({ tipo: "reset" });
 
-      alert("Nuovo test iniziato! Premi 'Nuova Carta' per iniziare il primo turno.");
+      finalMessageElem.textContent = "Nuovo test iniziato! Premi 'Nuova Carta' per iniziare il primo turno.";
     }
 
     function nextCard() {
       if (turno >= 25) {
-        alert("Hai già effettuato 25 turni. Il test è concluso.");
+        finalMessageElem.textContent = "Hai già effettuato 25 turni. Il test è concluso.";
         return;
       }
 


### PR DESCRIPTION
## Summary
- show all messages directly in the web page instead of using `alert`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68447e9aad188330a62dab8b6ac5752e