### PR TITLE
Add slider for variable draw count

### DIFF
--- a/medium.html
+++ b/medium.html
@@ -145,7 +145,7 @@
   <script>
   const info = document.getElementById("info");
   const finalMessageElem = document.getElementById("final-message");
-  const TOT_TURNI = 25;
+  let TOT_TURNI = 25;
   finalMessageElem.textContent = `0/${TOT_TURNI}`;
   const cards = document.querySelectorAll('.card');
     const canvasElement = document.getElementById('output_canvas');
@@ -235,6 +235,7 @@
 
     channel.onmessage = (e) => {
       if (e.data.tipo === "reset") {
+        TOT_TURNI = e.data.totTurni || TOT_TURNI;
         turnoCorrente = 0;
         cartaSegreta = null;
         selectedCard = null;

--- a/operatore.html
+++ b/operatore.html
@@ -101,6 +101,8 @@
     <div class="controls">
       <button onclick="iniziaPartita()" id="btn-inizia">Inizia Nuovo Test</button>
       <button onclick="nextCard()" id="btn-next">Nuova Carta</button>
+      <label>Numero lanci: <input type="range" id="num-turni" min="25" max="125" step="25" value="25"></label>
+      <span id="num-turni-display">25</span>
       <div>Turno: <span id="turno">0</span></div>
       <div id="card" class="card-image"></div>
     </div>
@@ -147,12 +149,21 @@
     const probMsgElem = document.getElementById("prob-msg");
     const btnNext = document.getElementById("btn-next");
     const finalMessageElem = document.getElementById("final-message");
+    const numTurniInput = document.getElementById("num-turni");
+    const numTurniDisplay = document.getElementById("num-turni-display");
 
     const channel = new BroadcastChannel("zener_test");
 
     let turno = 0;
     let cartaAttuale = null;
     const risultati = [];
+    let TOT_TURNI = parseInt(numTurniInput.value);
+
+    numTurniDisplay.textContent = TOT_TURNI;
+    numTurniInput.addEventListener('input', () => {
+      TOT_TURNI = parseInt(numTurniInput.value);
+      numTurniDisplay.textContent = TOT_TURNI;
+    });
 
     function creaMazzoZener() {
       let mazzo = [];
@@ -194,7 +205,7 @@
 
     function mostraRisultatoFinale() {
       const corrette = risultati.filter(r => r.segreta === r.predetta).length;
-      let messaggio = `Test completato. Risposte corrette: ${corrette}/25.\n`;
+    let messaggio = `Test completato. Risposte corrette: ${corrette}/${TOT_TURNI}.\n`;
 
       if (corrette >= 18) {
         messaggio += "✅ Con almeno 18 risposte esatte, il test è SUPERATO secondo il criterio del protocollo.";
@@ -202,15 +213,17 @@
         messaggio += "❌ Come meno di 18 risposte esatte, il test NON è superato secondo il criterio del protocollo.";
       }
 
-      const prob = probAtLeast(25, corrette, 0.2);
+      const prob = probAtLeast(TOT_TURNI, corrette, 0.2);
       const volte = prob > 0 ? (1 / prob).toFixed(2) : Infinity;
-      messaggio += `\nSi possono indovinare almeno ${corrette} risultati su 25 per puro caso 1 volta su ${volte}.`;
+      messaggio += `\nSi possono indovinare almeno ${corrette} risultati su ${TOT_TURNI} per puro caso 1 volta su ${volte}.`;
 
       finalMessageElem.textContent = messaggio;
       btnNext.disabled = true;
     }
 
     function iniziaPartita() {
+      TOT_TURNI = parseInt(numTurniInput.value);
+      numTurniDisplay.textContent = TOT_TURNI;
       turno = 0;
       cartaAttuale = null;
       risultati.length = 0;
@@ -224,19 +237,24 @@
       mazzo = creaMazzoZener();
 
       // Comunica il reset al medium
-      channel.postMessage({ tipo: "reset" });
+      channel.postMessage({ tipo: "reset", totTurni: TOT_TURNI });
 
       finalMessageElem.textContent = "Nuovo test iniziato! Premi 'Nuova Carta' per iniziare il primo turno.";
     }
 
     function nextCard() {
-      if (turno >= 25) {
-        finalMessageElem.textContent = "Hai già effettuato 25 turni. Il test è concluso.";
+      if (turno >= TOT_TURNI) {
+        finalMessageElem.textContent = `Hai già effettuato ${TOT_TURNI} turni. Il test è concluso.`;
         return;
       }
 
       btnNext.disabled = true;
-      mescolaMazzo(mazzo);
+
+      if (turno % 25 === 0) {
+        mazzo = creaMazzoZener();
+        mescolaMazzo(mazzo);
+      }
+
       cartaAttuale = mazzo.pop();
       turno++;
       turnoElem.textContent = turno;
@@ -268,7 +286,7 @@
         const volte = prob > 0 ? (1 / prob).toFixed(2) : Infinity;
         probMsgElem.textContent = `Si possono indovinare almeno ${corrette} risultati su ${risultati.length} per puro caso 1 volta su ${volte}`;
 
-        if (turno < 25) {
+        if (turno < TOT_TURNI) {
           btnNext.disabled = false;
         } else {
           mostraRisultatoFinale();


### PR DESCRIPTION
## Summary
- make number of draws selectable in *operatore.html*
- update logic to reshuffle the deck every 25 draws
- send chosen draw count to *medium.html*
- handle variable draw count when showing progress and results

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68448c337c008330a59751c143f2e7d0